### PR TITLE
Improve Google Business Profile dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # GMB_CODEX
+
+Cette application Flask permet de se connecter à l'API Google Business Profile via OAuth2 et d'afficher la liste de vos fiches dans un tableau de bord minimal.
+
+## Installation
+
+1. Créez un projet Google Cloud et activez l'API *Google Business Profile*.
+2. Configurez un identifiant OAuth 2.0 de type "Application Web" et téléchargez le fichier `client_secret.json` à placer à la racine du projet. Vous pouvez aussi définir les variables d'environnement `GOOGLE_CLIENT_ID` et `GOOGLE_CLIENT_SECRET` à la place du fichier.
+3. Installez les dépendances :
+
+```bash
+pip install -r requirements.txt
+```
+
+4. Lancez l'application :
+
+```bash
+python app/app.py
+```
+
+L'application s'exécute sur [http://localhost:5000](http://localhost:5000).
+
+## Fonctionnement
+
+Au premier lancement, un bouton de connexion Google s'affiche. Une fois l'utilisateur autorisé, l'application récupère les locations associées au compte et les présente dans le dashboard.
+
+Ce projet sert de base pour ajouter d'autres KPIs : note moyenne, nombre d'avis, etc.

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,91 @@
+import json
+import os
+
+from flask import Flask, redirect, url_for, session, request, render_template
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import Flow
+from googleapiclient.discovery import build
+
+app = Flask(__name__)
+app.secret_key = os.environ.get('FLASK_SECRET', 'change-me')
+
+SCOPES = ['https://www.googleapis.com/auth/business.manage']
+CLIENT_SECRETS_FILE = os.environ.get('GOOGLE_CLIENT_SECRETS', 'client_secret.json')
+
+@app.route('/')
+def index():
+    creds_info = session.get('creds')
+    if not creds_info:
+        return render_template('login.html')
+
+    creds = Credentials.from_authorized_user_info(json.loads(creds_info), SCOPES)
+
+    account_mgmt = build('mybusinessaccountmanagement', 'v1', credentials=creds)
+    accounts = account_mgmt.accounts().list().execute()
+    account_name = accounts.get('accounts', [{}])[0].get('name')
+
+    biz_info = build('mybusinessbusinessinformation', 'v1', credentials=creds)
+    locations = []
+    if account_name:
+        resp = biz_info.accounts().locations().list(parent=account_name, readMask='name,title,storefrontAddress').execute()
+        locations = resp.get('locations', [])
+
+    return render_template('dashboard.html', locations=locations)
+
+@app.route('/login')
+def login():
+    if os.path.exists(CLIENT_SECRETS_FILE):
+        flow = Flow.from_client_secrets_file(
+            CLIENT_SECRETS_FILE,
+            scopes=SCOPES,
+            redirect_uri=url_for('oauth2callback', _external=True))
+    else:
+        client_config = {
+            'web': {
+                'client_id': os.environ.get('GOOGLE_CLIENT_ID'),
+                'client_secret': os.environ.get('GOOGLE_CLIENT_SECRET'),
+                'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+                'token_uri': 'https://oauth2.googleapis.com/token',
+            }
+        }
+        flow = Flow.from_client_config(
+            client_config,
+            scopes=SCOPES,
+            redirect_uri=url_for('oauth2callback', _external=True))
+    authorization_url, state = flow.authorization_url(
+        access_type='offline',
+        include_granted_scopes='true')
+    session['state'] = state
+    return redirect(authorization_url)
+
+@app.route('/oauth2callback')
+def oauth2callback():
+    state = session['state']
+    if os.path.exists(CLIENT_SECRETS_FILE):
+        flow = Flow.from_client_secrets_file(
+            CLIENT_SECRETS_FILE,
+            scopes=SCOPES,
+            state=state,
+            redirect_uri=url_for('oauth2callback', _external=True))
+    else:
+        client_config = {
+            'web': {
+                'client_id': os.environ.get('GOOGLE_CLIENT_ID'),
+                'client_secret': os.environ.get('GOOGLE_CLIENT_SECRET'),
+                'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+                'token_uri': 'https://oauth2.googleapis.com/token',
+            }
+        }
+        flow = Flow.from_client_config(
+            client_config,
+            scopes=SCOPES,
+            state=state,
+            redirect_uri=url_for('oauth2callback', _external=True))
+
+    flow.fetch_token(authorization_response=request.url)
+    creds = flow.credentials
+    session['creds'] = creds.to_json()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="utf-8">
+    <title>Tableau de bord GMB</title>
+</head>
+<body>
+<h1>Vos fiches Google Business</h1>
+<table border="1">
+<tr><th>Nom</th><th>ID</th><th>Adresse</th></tr>
+{% for loc in locations %}
+<tr>
+    <td>{{ loc.title }}</td>
+    <td>{{ loc.name }}</td>
+    <td>{{ loc.storefrontAddress.addressLines | default([]) | join(', ') }}</td>
+</tr>
+{% endfor %}
+</table>
+</body>
+</html>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Connexion</title>
+</head>
+<body>
+  <h1>Connexion à Google</h1>
+  <a href="{{ url_for('login') }}">Se connecter</a>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+google-auth
+google-auth-oauthlib
+google-api-python-client


### PR DESCRIPTION
## Summary
- handle client secrets via env vars or file
- fetch accounts and locations with the official APIs
- parse session credentials correctly
- show storefront address in dashboard

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6844647e10fc83249ee722f40c0ab0e6